### PR TITLE
fix: add expo-asset dependency and improve Codespace setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,23 @@
 {
   "name": "HealthTracker Dev",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
-  "postCreateCommand": "npm install",
-  "forwardPorts": [8081],
+  "postCreateCommand": "npm install && npx expo install --fix",
+  "forwardPorts": [8081, 19000, 19001],
   "portsAttributes": {
     "8081": {
       "label": "Expo Metro",
       "onAutoForward": "silent"
+    },
+    "19000": {
+      "label": "Expo DevTools",
+      "onAutoForward": "silent"
+    },
+    "19001": {
+      "label": "Expo Packager",
+      "onAutoForward": "silent"
     }
+  },
+  "remoteEnv": {
+    "EXPO_NO_DOTENV": "1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@expo/vector-icons": "^14.0.0",
         "@react-native-async-storage/async-storage": "2.1.0",
         "expo": "~52.0.0",
+        "expo-asset": "~10.0.0",
         "expo-router": "~4.0.0",
         "expo-status-bar": "~2.0.0",
         "react": "18.3.1",
@@ -6394,6 +6395,189 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-asset": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-10.0.10.tgz",
+      "integrity": "sha512-0qoTIihB79k+wGus9wy0JMKq7DdenziVx3iUkGvMAy2azscSgWH6bd2gJ9CGnhC6JRd3qTMFBL0ou/fx7WZl7A==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-constants": "~16.0.0",
+        "invariant": "^2.2.4",
+        "md5-file": "^3.2.3"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-asset/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/expo-asset/node_modules/@expo/config": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-9.0.4.tgz",
+      "integrity": "sha512-g5ns5u1JSKudHYhjo1zaSfkJ/iZIcWmUmIQptMJZ6ag1C0ShL2sj8qdfU8MmAMuKLOgcIfSaiWlQnm4X3VJVkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "@expo/config-plugins": "~8.0.8",
+        "@expo/config-types": "^51.0.3",
+        "@expo/json-file": "^8.3.0",
+        "getenv": "^1.0.0",
+        "glob": "7.1.6",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0",
+        "slugify": "^1.3.4",
+        "sucrase": "3.34.0"
+      }
+    },
+    "node_modules/expo-asset/node_modules/@expo/config-plugins": {
+      "version": "8.0.11",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-8.0.11.tgz",
+      "integrity": "sha512-oALE1HwnLFthrobAcC9ocnR9KXLzfWEjgIe4CPe+rDsfC6GDs8dGYCXfRFoCEzoLN4TGYs9RdZ8r0KoCcNrm2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^51.0.3",
+        "@expo/json-file": "~8.3.0",
+        "@expo/plist": "^0.1.0",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.1",
+        "find-up": "~5.0.0",
+        "getenv": "^1.0.0",
+        "glob": "7.1.6",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.4",
+        "slash": "^3.0.0",
+        "slugify": "^1.6.6",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/expo-asset/node_modules/@expo/config-types": {
+      "version": "51.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-51.0.3.tgz",
+      "integrity": "sha512-hMfuq++b8VySb+m9uNNrlpbvGxYc8OcFCUX9yTmi9tlx6A4k8SDabWFBgmnr4ao3wEArvWrtUQIfQCVtPRdpKA==",
+      "license": "MIT"
+    },
+    "node_modules/expo-asset/node_modules/@expo/env": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-0.3.0.tgz",
+      "integrity": "sha512-OtB9XVHWaXidLbHvrVDeeXa09yvTl3+IQN884sO6PhIi2/StXfgSH/9zC7IvzrDB8kW3EBJ1PPLuCUJ2hxAT7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "debug": "^4.3.4",
+        "dotenv": "~16.4.5",
+        "dotenv-expand": "~11.0.6",
+        "getenv": "^1.0.0"
+      }
+    },
+    "node_modules/expo-asset/node_modules/@expo/json-file": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.3.3.tgz",
+      "integrity": "sha512-eZ5dld9AD0PrVRiIWpRkm5aIoWBw3kAyd8VkuWEy92sEthBKDDDHAnK2a0dw0Eil6j7rK7lS/Qaq/Zzngv2h5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.2",
+        "write-file-atomic": "^2.3.0"
+      }
+    },
+    "node_modules/expo-asset/node_modules/@expo/plist": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.1.3.tgz",
+      "integrity": "sha512-GW/7hVlAylYg1tUrEASclw1MMk9FP4ZwyFAY/SUTJIhPDQHtfOlXREyWV3hhrHdX/K+pS73GNgdfT6E/e+kBbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "~0.7.7",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^14.0.0"
+      }
+    },
+    "node_modules/expo-asset/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/expo-asset/node_modules/expo-constants": {
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-16.0.2.tgz",
+      "integrity": "sha512-9tNY3OVO0jfiMzl7ngb6IOyR5VFzNoN5OOazUWoeGfmMqVB5kltTemRvKraK9JRbBKIw+SOYLEmF0sEqgFZ6OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~9.0.0",
+        "@expo/env": "~0.3.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-asset/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/expo-asset/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-asset/node_modules/sucrase": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.34.0.tgz",
+      "integrity": "sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "7.1.6",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/expo-constants": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@expo/vector-icons": "^14.0.0",
     "@react-native-async-storage/async-storage": "2.1.0",
     "expo": "~52.0.0",
+    "expo-asset": "~10.0.0",
     "expo-router": "~4.0.0",
     "expo-status-bar": "~2.0.0",
     "react": "18.3.1",


### PR DESCRIPTION
- Add expo-asset ~10.0.0 as explicit dependency (required by Expo 52)
- Run npx expo install --fix after npm install to auto-correct peer versions
- Forward ports 19000/19001 alongside 8081 for full Expo tunnel support