### PR TITLE
fix: update expo-linking to ~8.0.11 to satisfy expo-router@6 peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@react-native-async-storage/async-storage": "2.2.0",
     "expo": "~54.0.0",
     "expo-asset": "~10.0.0",
-    "expo-linking": "~7.0.5",
+    "expo-linking": "~8.0.11",
     "expo-router": "~6.0.0",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",


### PR DESCRIPTION
expo-router@6.0.23 requires expo-linking@^8.0.11. The previous fix accidentally pinned expo-linking to ~7.0.5 (SDK 53 era), causing npm install to fail with an ERESOLVE conflict and blocking the tunnel.

https://claude.ai/code/session_01XGs7VB8ShHeiCCbgaR4HxQ