### PR TITLE
fix: add missing babel-preset-expo devDependency for SDK 54

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/core": "^7.24.0",
     "@expo/ngrok": "^4.1.3",
     "@types/react": "~19.1.10",
+    "babel-preset-expo": "~54.0.0",
     "typescript": "~5.9.2"
   }
 }


### PR DESCRIPTION
babel.config.js references babel-preset-expo but it was never listed in package.json, causing Metro bundling to fail immediately with "Cannot find module 'babel-preset-expo'". Pinned to ~54.0.0 to match the project's Expo SDK version.

https://claude.ai/code/session_01XGs7VB8ShHeiCCbgaR4HxQ