### PR TITLE
fix: update expo-asset to ~12.0.12, resolves icons crash and route re…

### DIFF
--- a/mobile_view.md
+++ b/mobile_view.md
@@ -168,3 +168,22 @@ Unable to resolve "expo-linking" from "node_modules/expo-router/build/views/Unma
 **Fix:** Applied both fixes to `.devcontainer/devcontainer.json`:
 - `postCreateCommand` updated to `npm install && npx expo install --fix` — automatically corrects any peer-dep version drift every time a Codespace is created
 - Ports **19000** (Expo DevTools) and **19001** (Expo Legacy) added to `forwardPorts` and `portsAttributes`
+
+---
+
+### Fix `expo-asset` version mismatch — icons crash and phantom route errors
+
+**Problem:** `expo-asset` was pinned to `~10.0.0` but Expo SDK 54 requires `~12.0.12`. The `expo-asset@10.x` package is missing the `setCustomSourceTransformer` API that `@expo/vector-icons@15.x` calls at import time to register icon font assets.
+
+This caused a crash the instant `Ionicons` was imported in `app/(tabs)/_layout.tsx`, which produced a cascade of misleading secondary errors:
+
+- `TypeError: setCustomSourceTransformer is not a function` — the direct crash
+- `Route "(tabs)/_layout.tsx" is missing the required default export` — the layout crashed before its `export default` could be evaluated
+- `Route "(tabs)/history.tsx" is missing the required default export` — same, because the tabs layout never registered this route
+- `Route "log-weight.tsx" is missing the required default export` — propagated from the root layout crash
+- `[Layout children]: No route named "(tabs)" exists` — the tabs group layout never loaded so expo-router couldn't register the `(tabs)` group at all
+- `[Layout children]: No route named "log-weight" exists` — same cascade
+
+All route files (`_layout.tsx`, `history.tsx`, `log-weight.tsx`) have correct `export default function` statements. There were no code bugs — only the version mismatch.
+
+**Fix:** Updated `expo-asset` from `~10.0.0` to `~12.0.12` in `package.json`.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@expo/vector-icons": "^15.0.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "expo": "~54.0.0",
-    "expo-asset": "~10.0.0",
+    "expo-asset": "~12.0.12",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.0",
     "expo-status-bar": "~3.0.9",


### PR DESCRIPTION
…gistration failures

expo-asset@10.x is missing the setCustomSourceTransformer API that @expo/vector-icons@15.x calls at import time. This caused a crash in app/(tabs)/_layout.tsx the moment Ionicons was imported, which triggered a cascade of phantom warnings: "missing default export" on route files that are actually correct, and "No route named (tabs)" because the tabs layout never finished loading.

Updating expo-asset to ~12.0.12 (as expected by SDK 54) fixes the root crash and resolves all secondary route registration errors.

Also documented the full error chain and fix in mobile_view.md.

https://claude.ai/code/session_01XGs7VB8ShHeiCCbgaR4HxQ