### PR TITLE
Add /dependency-check skill and trim docs

### DIFF
--- a/.claude/commands/dependency-check.md
+++ b/.claude/commands/dependency-check.md
@@ -1,0 +1,195 @@
+# Dependency Check — HealthTracker
+
+Reference this skill before installing any package, modifying `package.json`, or
+troubleshooting a Metro/npm error. It contains every version constraint, the reason
+each constraint exists, and the correct install commands.
+
+---
+
+## Always-On Rules
+
+Apply these on every install or package change — no exceptions:
+
+- **Always run:** `npm install --legacy-peer-deps`
+- **Always use:** `npx expo` (never bare `expo` — not reliably on PATH in Codespaces)
+- **Never upgrade a single package in isolation** without reading the pinned-package
+  notes below first
+- **Why `--legacy-peer-deps`?** This project uses `react@19.1.0`. Many packages have
+  transitive peer conflicts with `react-dom@19.2.4`. The `--legacy-peer-deps` flag
+  bypasses those without breaking anything functional. Omitting it causes npm to either
+  fail with `ERESOLVE` or silently remove correctly-installed packages.
+
+---
+
+## Pinned Packages — Constraints and Why
+
+### `expo-asset` — must be `~12.0.12`
+
+**Why:** `@expo/vector-icons@15.x` calls `setCustomSourceTransformer()` (exported from
+`expo-asset`) at import time to register icon font assets. This function does not exist
+in `expo-asset@10.x` (SDK 52 era) or `expo-asset@11.x`. Using the wrong version causes
+an immediate crash the moment any icon is imported. The crash cascades into a deceptive
+wave of secondary errors — "Route missing default export", "No route named (tabs) in
+nested children" — that look like code bugs but are not. The tabs layout never even
+reaches its `export default` because it crashes first.
+
+**Constraint:** `~12.0.12` (tilde, not caret — do not allow a minor bump)
+
+---
+
+### `expo-linking` — must be `~8.0.11`
+
+**Why:** `expo-router@6.0.x` declares `expo-linking@^8.0.11` as a required peer
+dependency. `expo-linking@7.x` is the SDK 53 era version. Using `7.x` causes an
+`npm ERESOLVE` that blocks `npm install` from completing at all, which means `expo`
+never gets installed locally, which causes `npm run tunnel` to fall back to
+`npx expo@latest` (wrong version) and fail with a `ConfigError`.
+
+**Constraint:** `~8.0.11`
+
+---
+
+### `react-native-worklets` — must be `0.5.1`
+
+**Why:** `react-native-reanimated@4.1.x` has a peer dependency on
+`react-native-worklets>=0.5.0`. The reanimated Babel plugin directly `require()`s
+`react-native-worklets/plugin` at Metro bundle time. If this package is missing or the
+wrong version, Metro fails immediately with
+`Cannot find module 'react-native-worklets/plugin'`.
+
+**Constraint:** `^0.5.1` in `package.json` (resolves to `0.5.1`)
+
+---
+
+### `react-refresh` — must be an explicit dep at `^0.14.2`
+
+**Why:** `babel-preset-expo` requires `react-refresh/babel` at Babel transform time.
+Although `react-refresh` is a transitive dependency of `react-native` and `expo`, npm
+with `--legacy-peer-deps` does not hoist it to top-level `node_modules`. Without an
+explicit entry in `package.json` `dependencies` (not `devDependencies`), Metro fails
+with `Cannot find module 'react-refresh/babel'`.
+
+**Constraint:** `^0.14.2` in `dependencies` (not `devDependencies`)
+
+---
+
+### `@react-native-community/datetimepicker` — must be `8.4.4`
+
+**Why:** Native date picker for iOS (spinner modal) and Android (inline calendar) used
+on the Weight screen. Has a `react-dom` peer conflict. Must be installed with
+`--legacy-peer-deps`.
+
+**Constraint:** `8.4.4` exact
+**Install:** `npm install --save @react-native-community/datetimepicker --legacy-peer-deps`
+
+---
+
+### `babel-preset-expo` — must be `~54.0.0` in devDependencies
+
+**Why:** `babel.config.js` references `babel-preset-expo` by name. npm does not
+auto-install peer dependencies. If it is absent from `package.json`, Metro fails
+immediately at bundling time with `Cannot find module 'babel-preset-expo'`. The version
+must match the SDK (`~54.0.0` for SDK 54).
+
+**Constraint:** `~54.0.0` in `devDependencies`
+
+---
+
+### `expo-linking` — must be `~8.0.11`
+
+See above. The key point: `expo-router@6` requires `expo-linking@^8`. Any `7.x` version
+breaks the install entirely.
+
+---
+
+### `react-native-draggable-flatlist` — install with `--legacy-peer-deps`
+
+**Why:** Has a transitive peer conflict with `react-dom@19.2.4` vs the project's
+`react@19.1.0`. Already installed at `^4.0.3`.
+
+**Install if re-adding:** `npm install --save react-native-draggable-flatlist --legacy-peer-deps`
+
+---
+
+## Full Dependency Table (SDK 54 working state)
+
+| Package | Version | Type |
+|---------|---------|------|
+| `expo` | `~54.0.0` | dep |
+| `expo-router` | `~6.0.0` | dep |
+| `expo-asset` | `~12.0.12` | dep |
+| `expo-linking` | `~8.0.11` | dep |
+| `expo-status-bar` | `~3.0.9` | dep |
+| `react` | `19.1.0` | dep |
+| `react-native` | `0.81.5` | dep |
+| `@expo/vector-icons` | `^15.0.0` | dep |
+| `@react-native-async-storage/async-storage` | `2.2.0` | dep |
+| `@react-native-community/datetimepicker` | `8.4.4` | dep |
+| `react-native-chart-kit` | `^6.12.0` | dep |
+| `react-native-gesture-handler` | `~2.28.0` | dep |
+| `react-native-reanimated` | `~4.1.1` | dep |
+| `react-native-safe-area-context` | `~5.6.0` | dep |
+| `react-native-screens` | `~4.16.0` | dep |
+| `react-native-draggable-flatlist` | `^4.0.3` | dep |
+| `react-native-svg` | `15.12.1` | dep |
+| `react-native-worklets` | `^0.5.1` | dep |
+| `react-refresh` | `^0.14.2` | dep |
+| `@babel/core` | `^7.24.0` | devDep |
+| `@expo/ngrok` | `^4.1.3` | devDep |
+| `@types/react` | `~19.1.10` | devDep |
+| `babel-preset-expo` | `~54.0.0` | devDep |
+| `typescript` | `~5.9.2` | devDep |
+
+---
+
+## Error Symptom Lookup
+
+Use this table when you encounter an install or runtime error. Find the symptom, read
+the root cause, then apply the fix — do not guess or try random version bumps.
+
+| Symptom | Root cause | Fix |
+|---------|-----------|-----|
+| `setCustomSourceTransformer is not a function` | `expo-asset` wrong version | Ensure `expo-asset` is `~12.0.12` |
+| "Route missing default export" / "No route named (tabs)" | Usually the `expo-asset` crash cascading (not actual code bugs) | Fix `expo-asset` version first; don't touch route files |
+| `npm ERESOLVE` on install | `expo-linking` version mismatch | Ensure `expo-linking` is `~8.0.11` |
+| `Cannot find module 'react-native-worklets/plugin'` | `react-native-worklets` missing or wrong version | Ensure `react-native-worklets` is `^0.5.1` |
+| `Cannot find module 'react-refresh/babel'` | `react-refresh` not hoisted by `--legacy-peer-deps` | Add `react-refresh ^0.14.2` to `dependencies` explicitly |
+| `Cannot find module 'babel-preset-expo'` | Missing from `devDependencies` | Add `babel-preset-expo ~54.0.0` to `devDeps`; run `npm install` |
+| npm removes packages or breaks tree after install | `--legacy-peer-deps` was omitted | Re-run with `--legacy-peer-deps` |
+| `ConfigError` from `npx expo@latest` | `expo` not locally installed; fell back to global latest | Run `npm install` to restore local `expo`; use `npx expo` not bare `expo` |
+
+---
+
+## Evaluating New Packages
+
+Before adding any new package, check these in order:
+
+1. **Does it have a `react-dom` peer dep?** If yes, you must use `--legacy-peer-deps` on install.
+2. **Does it depend on `react-native-reanimated` or `react-native-gesture-handler`?**
+   If yes, verify it supports the versions already installed (`~4.1.1` and `~2.28.0`).
+3. **Is it an Expo SDK package (`expo-*`)?** If yes, verify it targets SDK 54. Use
+   `npx expo install <package>` to get the SDK-matched version automatically.
+4. **Does it require a native module?** If yes, confirm it works with Expo managed
+   workflow (no ejecting). Check the Expo docs.
+5. **Does it ship a Babel plugin?** If yes, add it to `babel.config.js` plugins array
+   and restart Metro (`Ctrl+C` + `npm start`).
+
+---
+
+## History — Why These Constraints Exist
+
+This project was originally scaffolded at SDK 52. The constraints above are the result
+of the following fixes applied during the SDK 52 → 54 migration:
+
+| Fix applied | What changed |
+|------------|-------------|
+| SDK 52 → 54 upgrade | All `expo-*` and `react-native-*` packages bumped to SDK 54 equivalents |
+| `expo-linking` added at `~7.0.5` | Was entirely missing; added as explicit dep for expo-router peer dep |
+| `expo-linking` corrected to `~8.0.11` | `~7.0.5` is SDK 53 era; `expo-router@6` requires `^8.0.11` |
+| `babel-preset-expo ~54.0.0` added to devDeps | Was entirely missing; Metro cannot bundle without it |
+| `expo-asset` corrected to `~12.0.12` | `~10.0.0` lacked `setCustomSourceTransformer`; caused icons crash + phantom route errors |
+| All scripts switched to `npx expo` | Bare `expo` command unreliable on PATH in Codespaces |
+| `react-native-worklets ^0.5.1` added as explicit dep | Required peer of `react-native-reanimated@4.1.x` Babel plugin |
+| `react-refresh ^0.14.2` added as explicit dep | `--legacy-peer-deps` doesn't hoist it; `babel-preset-expo` needs it at top level |
+| `@react-native-community/datetimepicker 8.4.4` added | Native date picker for consolidated Weight screen |
+| `react-native-draggable-flatlist ^4.0.3` added | Drag-to-reorder for Nutrition meal categories |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,12 +33,6 @@ No test runner or lint script exists in package.json.
 
 - **`GestureHandlerRootView`** wraps the entire app in `app/_layout.tsx` — required by `react-native-gesture-handler` and any library that depends on it (e.g., `react-native-draggable-flatlist`). Must be the outermost wrapper.
 
-## Critical Dependency Constraints
+## Dependency Management
 
-- `expo-asset` must stay at `~12.0.12` — lower versions crash vector-icons
-- `expo-linking` must stay at `~8.0.11` — expo-router peer dep
-- `react-native-worklets` must stay at `0.5.1` — required peer dep of `react-native-reanimated@4.1.x`
-- `react-refresh` must be an explicit dep at `^0.14.2` — npm with `--legacy-peer-deps` doesn't hoist it; `babel-preset-expo` needs it at top level
-- `@react-native-community/datetimepicker` at `8.4.4` — native date picker for Weight screen
-- **Always use `--legacy-peer-deps`** when running `npm install` — multiple packages have `react-dom` peer conflicts with `react@19.1.0`
-- All scripts use `npx expo` (not bare `expo`)
+For all version constraints, compatibility rules, and install commands, use the `/dependency-check` skill.

--- a/README.md
+++ b/README.md
@@ -224,73 +224,6 @@ This is the no-install workflow — runs entirely in the browser with no local s
 
 > **Free tier:** GitHub Free gets ~60 core-hours/month (roughly 60 hours on a 2-core Codespace). You'll receive an email warning before hitting the limit.
 
----
-
-## Dependency Reference
-
-> **Important for future changes:** This project has a history of dependency version conflicts from its original SDK 52 scaffolding. Always use the exact version ranges below and never upgrade a single package in isolation without checking the constraint notes.
-
-### Working versions (SDK 54)
-
-| Package | Version | Type |
-|---------|---------|------|
-| `expo` | `~54.0.0` | dep |
-| `expo-router` | `~6.0.0` | dep |
-| `expo-asset` | `~12.0.12` | dep |
-| `expo-linking` | `~8.0.11` | dep |
-| `expo-status-bar` | `~3.0.9` | dep |
-| `react` | `19.1.0` | dep |
-| `react-native` | `0.81.5` | dep |
-| `@expo/vector-icons` | `^15.0.0` | dep |
-| `@react-native-async-storage/async-storage` | `2.2.0` | dep |
-| `@react-native-community/datetimepicker` | `^8.4.4` | dep |
-| `react-native-chart-kit` | `^6.12.0` | dep |
-| `react-native-gesture-handler` | `~2.28.0` | dep |
-| `react-native-reanimated` | `~4.1.1` | dep |
-| `react-native-safe-area-context` | `~5.6.0` | dep |
-| `react-native-screens` | `~4.16.0` | dep |
-| `react-native-draggable-flatlist` | `^4.0.3` | dep |
-| `react-native-svg` | `15.12.1` | dep |
-| `react-native-worklets` | `0.5.1` | dep |
-| `react-refresh` | `^0.14.2` | dep |
-| `@react-native-community/datetimepicker` | `8.4.4` | dep |
-| `@babel/core` | `^7.24.0` | devDep |
-| `@expo/ngrok` | `^4.1.3` | devDep |
-| `@types/react` | `~19.1.10` | devDep |
-| `babel-preset-expo` | `~54.0.0` | devDep |
-| `typescript` | `~5.9.2` | devDep |
-
-### Version constraints — do not change without reading this
-
-**`expo-asset` must be `~12.0.12`**
-`@expo/vector-icons@15.x` calls `setCustomSourceTransformer` (from `expo-asset`) at import time to register icon font assets. This function does not exist in `expo-asset@10.x` (SDK 52 era) or `expo-asset@11.x`. Using the wrong version causes a crash the instant any icon is imported, which produces a deceptive cascade of secondary errors: "Route missing default export", "No route named (tabs) in nested children", etc. None of those routes have actual code bugs — they all fail because the tabs layout crashes before its `export default` is evaluated.
-
-**`expo-linking` must be `~8.0.11`**
-`expo-router@6.0.x` declares `expo-linking@^8.0.11` as a required peer dependency. `expo-linking@7.x` is the SDK 53 era version and will cause an `npm ERESOLVE` error that prevents `npm install` from completing at all, which in turn prevents `expo` from being installed locally, which causes `npm run tunnel` to fall back to `npx expo@latest` (wrong version) and then fail with a `ConfigError`.
-
-**`babel-preset-expo` must be an explicit `devDependency` at `~54.0.0`**
-`babel.config.js` references `babel-preset-expo` by name. npm does not auto-install peer dependencies. If it is absent from `package.json`, Metro fails immediately at bundling time with `Cannot find module 'babel-preset-expo'`. The version must match the SDK (`~54.0.0` for SDK 54).
-
-**`react-native-draggable-flatlist` requires `--legacy-peer-deps`**
-This package has a transitive peer conflict with `react-dom@19.2.4` vs the project's `react@19.1.0`. Install with `npm install --save react-native-draggable-flatlist --legacy-peer-deps`.
-
-**`react-native-worklets` must be `0.5.1`**
-`react-native-reanimated@4.1.x` has a peer dependency on `react-native-worklets>=0.5.0`. The reanimated babel plugin directly `require()`s `react-native-worklets/plugin`. Without it, Metro fails with `Cannot find module 'react-native-worklets/plugin'`.
-
-**`react-refresh` must be an explicit dependency at `^0.14.2`**
-`babel-preset-expo` requires `react-refresh/babel` at transform time. Although `react-refresh` is a transitive dependency of `react-native`, `@react-native/babel-preset`, and `expo`, npm with `--legacy-peer-deps` does not hoist it to the top-level `node_modules`. Without an explicit entry in `package.json`, Metro fails with `Cannot find module 'react-refresh/babel'`.
-
-**`@react-native-community/datetimepicker` requires `--legacy-peer-deps`**
-Same `react-dom` peer conflict as `react-native-draggable-flatlist`. Install with `npm install --save @react-native-community/datetimepicker --legacy-peer-deps`.
-
-**Always use `--legacy-peer-deps` when installing packages**
-Multiple packages in this project have transitive peer conflicts with `react-dom@19.2.4` vs the project's `react@19.1.0`. Always run `npm install --legacy-peer-deps` to avoid resolution failures and to prevent npm from removing correctly-installed packages.
-
-**`expo-router` scripts must use `npx expo`, not bare `expo`**
-In a Codespace, `node_modules/.bin` is not always on `PATH`. `npx expo` resolves the locally installed binary reliably. All scripts in `package.json` use `npx expo start`, `npx expo run:android`, etc.
-
----
-
 ## Troubleshooting
 
 | Problem | Fix |
@@ -301,26 +234,4 @@ In a Codespace, `node_modules/.bin` is not always on `PATH`. `npx expo` resolves
 | `@expo/ngrok` not found | Run `npm install` first, then retry `npm run tunnel` |
 | Codespace went to sleep | Reopen it at github.com → Codespaces, then run `npm run tunnel` again |
 | "Something went wrong" in Expo Go | Stop Expo (`Ctrl+C`), run `npm run tunnel` again, rescan QR code |
-| `Cannot find module 'babel-preset-expo'` | Run `npm install` — this package was missing from devDependencies and has since been added |
-| `setCustomSourceTransformer is not a function` | `expo-asset` version mismatch — ensure `expo-asset` is `~12.0.12` in `package.json` |
-| `npm ERESOLVE` on install | `expo-linking` version mismatch — ensure `expo-linking` is `~8.0.11` |
-| Route "missing default export" warnings | Usually a symptom of the `expo-asset`/`setCustomSourceTransformer` crash above, not an actual code error |
 
----
-
-## Fix History
-
-Condensed log of dependency fixes applied after the initial SDK 52 scaffold:
-
-| Fix | What changed |
-|-----|-------------|
-| Upgrade SDK 52 → 54 | All Expo + RN packages bumped to SDK 54 equivalents |
-| `expo-linking` added at `~7.0.5` | Was missing; added as explicit dep for expo-router peer dep |
-| `expo-linking` corrected to `~8.0.11` | `~7.0.5` was SDK 53 era; expo-router@6 requires `^8.0.11` |
-| `babel-preset-expo ~54.0.0` added to devDeps | Was entirely missing; Metro cannot bundle without it |
-| `expo-asset` corrected to `~12.0.12` | `~10.0.0` lacked `setCustomSourceTransformer`; caused icons crash and phantom route errors |
-| All scripts switched to `npx expo` | Bare `expo` command not reliably on PATH in Codespaces |
-| `.devcontainer` updated | `postCreateCommand` runs `npm install && npx expo install --fix`; ports 19000 + 19001 forwarded |
-| Consolidate History + Log into single screen | Removed `history.tsx` and `log-weight.tsx`; `index.tsx` now contains a Log/History toggle with inline date picker; tab bar reduced from 3 tabs to 2 (Weight + Settings) |
-| `@react-native-community/datetimepicker` added | Native date picker for iOS (spinner modal) and Android (inline); required for date selection on the consolidated Weight screen |
-| Nutrition feature (Phases 1–3) | Added Nutrition tab with TDEE calculation, calorie/macro tracking, OpenFoodFacts search, custom foods, saved meals, drag-to-reorder, swipe-to-delete. Added `react-native-draggable-flatlist` dependency. Tab bar expanded from 2 to 3 tabs. |


### PR DESCRIPTION
- Create .claude/commands/dependency-check.md: full dependency skill with pinned package constraints + WHY explanations, version table, error symptom lookup, new-package checklist, and SDK 52→54 fix history
- Replace CLAUDE.md "Critical Dependency Constraints" section with a one-line pointer to the /dependency-check skill (keeps root CLAUDE.md lean; dependency details live in the skill)
- Remove README.md "Dependency Reference" section (~63 lines), "Fix History" section (~17 lines), and 4 dependency-version troubleshooting rows — all now covered by the skill

https://claude.ai/code/session_01YJLVWucXUXXTRvVgBgeoiK