### PR TITLE
feat: Phase 6 — drum pickers, macro stepper buttons, and custom food …

### DIFF
--- a/components/nutrition/AddFoodTab.tsx
+++ b/components/nutrition/AddFoodTab.tsx
@@ -73,6 +73,15 @@ const makeStyles = (colors: typeof LightColors) =>
       textAlign: 'center',
       padding: Spacing.lg,
     },
+    sectionHeader: {
+      ...Typography.small,
+      color: colors.textSecondary,
+      textTransform: 'uppercase',
+      letterSpacing: 0.8,
+      paddingHorizontal: Spacing.md,
+      paddingVertical: Spacing.xs,
+      backgroundColor: colors.background,
+    },
     portionPanel: {
       backgroundColor: colors.card,
       borderBottomWidth: 1,
@@ -130,12 +139,14 @@ export default function AddFoodTab({ date, category, onDone }: Props) {
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
-  // Filter custom foods by query
-  const filteredCustomFoods = query.trim().length >= 2
-    ? customFoods.filter((f) =>
-        f.name.toLowerCase().includes(query.trim().toLowerCase()),
-      )
-    : [];
+  // Filter custom foods by query — show all when empty, filter at 1+ chars
+  const trimmed = query.trim();
+  const filteredCustomFoods =
+    trimmed.length === 0
+      ? customFoods
+      : customFoods.filter((f) =>
+          f.name.toLowerCase().includes(trimmed.toLowerCase()),
+        );
 
   // Convert custom foods to NutritionFoodItem format for display
   const customResults: NutritionFoodItem[] = filteredCustomFoods.map((f) => ({
@@ -284,8 +295,13 @@ export default function AddFoodTab({ date, category, onDone }: Props) {
               </Text>
             </TouchableOpacity>
           )}
+          ListHeaderComponent={
+            trimmed.length === 0 && filteredCustomFoods.length > 0 ? (
+              <Text style={styles.sectionHeader}>My Foods</Text>
+            ) : null
+          }
           ListEmptyComponent={
-            searched && !loading ? (
+            searched && !loading && trimmed.length >= 2 ? (
               <Text style={styles.empty}>No results found</Text>
             ) : null
           }

--- a/components/nutrition/CreateMealFlow.tsx
+++ b/components/nutrition/CreateMealFlow.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -155,17 +155,64 @@ export default function CreateMealFlow({ onDone }: Props) {
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
+  // Show all custom foods on initial mount (query is empty)
+  useEffect(() => {
+    const allCustom: NutritionFoodItem[] = customFoods.map((f) => ({
+      id: f.id,
+      name: f.name,
+      calories: f.calories,
+      protein: f.protein,
+      carbs: f.carbs,
+      fat: f.fat,
+      servingSize: f.servingSize,
+      servings: 1,
+    }));
+    setSearchResults(allCustom);
+  }, []);
+
   const handleSearch = useCallback(
     (text: string) => {
       setQuery(text);
 
       if (debounceRef.current) clearTimeout(debounceRef.current);
 
-      if (text.trim().length < 2) {
-        setSearchResults([]);
+      const trimmedText = text.trim();
+
+      // When empty: show all custom foods immediately, no USDA call
+      if (trimmedText.length === 0) {
+        const allCustom: NutritionFoodItem[] = customFoods.map((f) => ({
+          id: f.id,
+          name: f.name,
+          calories: f.calories,
+          protein: f.protein,
+          carbs: f.carbs,
+          fat: f.fat,
+          servingSize: f.servingSize,
+          servings: 1,
+        }));
+        setSearchResults(allCustom);
         return;
       }
 
+      // When 1 char: filter custom foods only, no USDA call
+      if (trimmedText.length === 1) {
+        const matchingCustom: NutritionFoodItem[] = customFoods
+          .filter((f) => f.name.toLowerCase().includes(trimmedText.toLowerCase()))
+          .map((f) => ({
+            id: f.id,
+            name: f.name,
+            calories: f.calories,
+            protein: f.protein,
+            carbs: f.carbs,
+            fat: f.fat,
+            servingSize: f.servingSize,
+            servings: 1,
+          }));
+        setSearchResults(matchingCustom);
+        return;
+      }
+
+      // 2+ chars: filter custom + USDA
       debounceRef.current = setTimeout(async () => {
         if (abortRef.current) abortRef.current.abort();
         const controller = new AbortController();
@@ -173,9 +220,8 @@ export default function CreateMealFlow({ onDone }: Props) {
 
         setLoading(true);
         try {
-          // Search both custom foods and USDA
           const matchingCustom: NutritionFoodItem[] = customFoods
-            .filter((f) => f.name.toLowerCase().includes(text.trim().toLowerCase()))
+            .filter((f) => f.name.toLowerCase().includes(trimmedText.toLowerCase()))
             .map((f) => ({
               id: f.id,
               name: f.name,
@@ -187,7 +233,7 @@ export default function CreateMealFlow({ onDone }: Props) {
               servings: 1,
             }));
 
-          const { items } = await searchFoods(text.trim(), 1, controller.signal);
+          const { items } = await searchFoods(trimmedText, 1, controller.signal);
           setSearchResults([...matchingCustom, ...items]);
         } catch (e: unknown) {
           if (e instanceof Error && e.name === 'AbortError') return;
@@ -261,7 +307,9 @@ export default function CreateMealFlow({ onDone }: Props) {
 
       {searchResults.length > 0 && (
         <>
-          <Text style={styles.sectionLabel}>Search Results</Text>
+          <Text style={styles.sectionLabel}>
+            {query.trim().length === 0 ? 'My Foods' : 'Search Results'}
+          </Text>
           <FlatList
             data={searchResults.slice(0, 10)}
             keyExtractor={(item, i) => `${item.id}-${i}`}

--- a/components/nutrition/PortionSelector.tsx
+++ b/components/nutrition/PortionSelector.tsx
@@ -5,8 +5,9 @@ import {
   TextInput,
   TouchableOpacity,
   StyleSheet,
-  PanResponder,
-  LayoutChangeEvent,
+  ScrollView,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import {
@@ -21,6 +22,11 @@ import {
 const FRACTIONS = [0, 1 / 8, 2 / 8, 3 / 8, 4 / 8, 5 / 8, 6 / 8, 7 / 8];
 const FRACTION_LABELS = ['0', '⅛', '¼', '⅜', '½', '⅝', '¾', '⅞'];
 const WHOLE_MAX = 250;
+
+const ITEM_HEIGHT = 44;
+const VISIBLE_ITEMS = 5;
+const DRUM_HEIGHT = ITEM_HEIGHT * VISIBLE_ITEMS; // 220
+const PAD_COUNT = Math.floor(VISIBLE_ITEMS / 2); // 2
 
 const makeStyles = (colors: typeof LightColors) =>
   StyleSheet.create({
@@ -59,78 +65,6 @@ const makeStyles = (colors: typeof LightColors) =>
       textAlign: 'center',
       marginBottom: Spacing.sm,
     },
-    sliderSection: {
-      marginBottom: Spacing.sm,
-    },
-    sliderLabel: {
-      ...Typography.small,
-      color: colors.textSecondary,
-      marginBottom: Spacing.xs,
-    },
-    sliderRow: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: Spacing.sm,
-    },
-    sliderTrack: {
-      flex: 1,
-      height: 6,
-      backgroundColor: colors.border,
-      borderRadius: 3,
-      justifyContent: 'center',
-    },
-    sliderFill: {
-      position: 'absolute',
-      left: 0,
-      top: 0,
-      height: 6,
-      backgroundColor: colors.primary,
-      borderRadius: 3,
-    },
-    sliderThumb: {
-      position: 'absolute',
-      width: 22,
-      height: 22,
-      borderRadius: 11,
-      backgroundColor: colors.primary,
-      marginTop: -8,
-      shadowColor: '#000',
-      shadowOffset: { width: 0, height: 2 },
-      shadowOpacity: 0.2,
-      shadowRadius: 3,
-      elevation: 3,
-    },
-    sliderValue: {
-      ...Typography.small,
-      color: colors.text,
-      fontWeight: '600',
-      minWidth: 32,
-      textAlign: 'right',
-    },
-    fractionRow: {
-      flexDirection: 'row',
-      gap: 4,
-      flexWrap: 'wrap',
-    },
-    fractionChip: {
-      flex: 1,
-      minWidth: 36,
-      paddingVertical: Spacing.xs,
-      backgroundColor: colors.background,
-      borderRadius: Radius.sm,
-      alignItems: 'center',
-    },
-    fractionChipActive: {
-      backgroundColor: colors.primary,
-    },
-    fractionText: {
-      ...Typography.small,
-      color: colors.textSecondary,
-      fontWeight: '600',
-    },
-    fractionTextActive: {
-      color: colors.white,
-    },
     keypadInput: {
       backgroundColor: colors.card,
       borderRadius: Radius.md,
@@ -163,6 +97,54 @@ const makeStyles = (colors: typeof LightColors) =>
     previewLabel: {
       ...Typography.small,
       color: colors.textSecondary,
+    },
+    drumWrapper: {
+      flexDirection: 'row',
+      justifyContent: 'center',
+      gap: Spacing.md,
+      marginBottom: Spacing.sm,
+    },
+    drumContainer: {
+      width: 110,
+      height: DRUM_HEIGHT,
+      overflow: 'hidden',
+      borderRadius: Radius.md,
+      backgroundColor: colors.background,
+    },
+    drumScroll: {
+      flex: 1,
+    },
+    drumItem: {
+      height: ITEM_HEIGHT,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    drumItemText: {
+      ...Typography.body,
+      color: colors.textSecondary,
+    },
+    drumItemTextSelected: {
+      ...Typography.h3,
+      color: colors.text,
+      fontWeight: '700',
+    },
+    drumHighlight: {
+      position: 'absolute',
+      top: ITEM_HEIGHT * PAD_COUNT,
+      left: 0,
+      right: 0,
+      height: ITEM_HEIGHT,
+      borderTopWidth: 1,
+      borderBottomWidth: 1,
+      borderColor: colors.primary,
+      backgroundColor: colors.primaryLight,
+      borderRadius: Radius.sm,
+    },
+    drumLabel: {
+      ...Typography.small,
+      color: colors.textSecondary,
+      textAlign: 'center',
+      marginBottom: Spacing.xs,
     },
   });
 
@@ -198,9 +180,10 @@ export default function PortionSelector({
   const [fractionIndex, setFractionIndex] = useState(initialFracIndex);
   const [keypadInput, setKeypadInput] = useState(value.toString());
 
-  const wholeTrackWidth = useRef(0);
+  const wholeScrollRef = useRef<ScrollView>(null);
+  const fracScrollRef = useRef<ScrollView>(null);
 
-  // Notify parent whenever sliders change
+  // Notify parent whenever drums change
   useEffect(() => {
     if (!keypadMode) {
       const total = wholeValue + FRACTIONS[fractionIndex];
@@ -208,23 +191,25 @@ export default function PortionSelector({
     }
   }, [wholeValue, fractionIndex, keypadMode]);
 
-  const wholePan = useRef(
-    PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponder: () => true,
-      onPanResponderGrant: (_, gs) => {
-        const pct = Math.min(1, Math.max(0, gs.x0 / (wholeTrackWidth.current || 1)));
-        setWholeValue(Math.round(pct * WHOLE_MAX));
-      },
-      onPanResponderMove: (_, gs) => {
-        const pct = Math.min(1, Math.max(0, gs.moveX / (wholeTrackWidth.current || 1)));
-        setWholeValue(Math.round(pct * WHOLE_MAX));
-      },
-    }),
-  ).current;
+  // Position drums to initial value on mount
+  useEffect(() => {
+    const t = setTimeout(() => {
+      wholeScrollRef.current?.scrollTo({ y: initialWhole * ITEM_HEIGHT, animated: false });
+      fracScrollRef.current?.scrollTo({ y: initialFracIndex * ITEM_HEIGHT, animated: false });
+    }, 50);
+    return () => clearTimeout(t);
+  }, []);
 
-  const handleWholeTrackLayout = (e: LayoutChangeEvent) => {
-    wholeTrackWidth.current = e.nativeEvent.layout.width;
+  const handleWholeScroll = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const index = Math.round(e.nativeEvent.contentOffset.y / ITEM_HEIGHT);
+    const clamped = Math.max(0, Math.min(WHOLE_MAX, index));
+    if (clamped !== wholeValue) setWholeValue(clamped);
+  };
+
+  const handleFracScroll = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const index = Math.round(e.nativeEvent.contentOffset.y / ITEM_HEIGHT);
+    const clamped = Math.max(0, Math.min(FRACTIONS.length - 1, index));
+    if (clamped !== fractionIndex) setFractionIndex(clamped);
   };
 
   const handleKeypadChange = (text: string) => {
@@ -237,15 +222,19 @@ export default function PortionSelector({
 
   const toggleMode = () => {
     if (keypadMode) {
-      // Switching back to sliders — sync slider state from keypad value
+      // Switching back to drums — sync drum state from keypad value
       const n = parseFloat(keypadInput) || 0;
       const whole = Math.min(WHOLE_MAX, Math.floor(n));
       const fracIdx = Math.min(7, Math.round((n - whole) * 8));
       setWholeValue(whole);
       setFractionIndex(fracIdx);
       setKeypadMode(false);
+      setTimeout(() => {
+        wholeScrollRef.current?.scrollTo({ y: whole * ITEM_HEIGHT, animated: false });
+        fracScrollRef.current?.scrollTo({ y: fracIdx * ITEM_HEIGHT, animated: false });
+      }, 50);
     } else {
-      // Switching to keypad — show current slider value
+      // Switching to keypad — show current drum value
       const total = wholeValue + FRACTIONS[fractionIndex];
       setKeypadInput(total % 1 === 0 ? total.toString() : total.toFixed(4).replace(/0+$/, ''));
       setKeypadMode(true);
@@ -272,8 +261,6 @@ export default function PortionSelector({
       ? fractionLabel
       : `${wholeValue} ${fractionLabel}`;
 
-  const thumbPct = WHOLE_MAX > 0 ? wholeValue / WHOLE_MAX : 0;
-
   return (
     <View style={styles.container}>
       {/* Header row */}
@@ -287,7 +274,7 @@ export default function PortionSelector({
             size={16}
             color={colors.primary}
           />
-          <Text style={styles.toggleBtnText}>{keypadMode ? 'Sliders' : 'Keypad'}</Text>
+          <Text style={styles.toggleBtnText}>{keypadMode ? 'Drums' : 'Keypad'}</Text>
         </TouchableOpacity>
       </View>
 
@@ -304,56 +291,78 @@ export default function PortionSelector({
         />
       ) : (
         <>
-          {/* Whole number slider */}
-          <View style={styles.sliderSection}>
-            <Text style={styles.sliderLabel}>Whole servings</Text>
-            <View style={styles.sliderRow}>
-              <View
-                style={styles.sliderTrack}
-                onLayout={handleWholeTrackLayout}
-                {...wholePan.panHandlers}
-              >
-                <View style={[styles.sliderFill, { width: `${thumbPct * 100}%` }]} />
-                <View
-                  style={[
-                    styles.sliderThumb,
-                    { left: `${thumbPct * 100}%`, marginLeft: -11 },
-                  ]}
-                />
-              </View>
-              <Text style={styles.sliderValue}>{wholeValue}</Text>
-            </View>
-          </View>
-
-          {/* Fraction selector */}
-          <View style={styles.sliderSection}>
-            <Text style={styles.sliderLabel}>Fraction (⅛ increments)</Text>
-            <View style={styles.fractionRow}>
-              {FRACTION_LABELS.map((label, i) => (
-                <TouchableOpacity
-                  key={i}
-                  style={[
-                    styles.fractionChip,
-                    fractionIndex === i && styles.fractionChipActive,
-                  ]}
-                  onPress={() => setFractionIndex(i)}
-                  activeOpacity={0.8}
+          <View style={styles.drumWrapper}>
+            {/* Whole number drum */}
+            <View>
+              <Text style={styles.drumLabel}>Whole</Text>
+              <View style={styles.drumContainer}>
+                <View style={styles.drumHighlight} pointerEvents="none" />
+                <ScrollView
+                  ref={wholeScrollRef}
+                  style={styles.drumScroll}
+                  showsVerticalScrollIndicator={false}
+                  snapToInterval={ITEM_HEIGHT}
+                  decelerationRate="fast"
+                  scrollEventThrottle={16}
+                  onMomentumScrollEnd={handleWholeScroll}
+                  onScrollEndDrag={handleWholeScroll}
+                  contentContainerStyle={{ paddingVertical: ITEM_HEIGHT * PAD_COUNT }}
                 >
-                  <Text
-                    style={[
-                      styles.fractionText,
-                      fractionIndex === i && styles.fractionTextActive,
-                    ]}
-                  >
-                    {label}
-                  </Text>
-                </TouchableOpacity>
-              ))}
+                  {Array.from({ length: WHOLE_MAX + 1 }, (_, i) => (
+                    <View key={i} style={styles.drumItem}>
+                      <Text
+                        style={
+                          i === wholeValue
+                            ? styles.drumItemTextSelected
+                            : styles.drumItemText
+                        }
+                      >
+                        {i}
+                      </Text>
+                    </View>
+                  ))}
+                </ScrollView>
+              </View>
+            </View>
+
+            {/* Fraction drum */}
+            <View>
+              <Text style={styles.drumLabel}>Fraction</Text>
+              <View style={styles.drumContainer}>
+                <View style={styles.drumHighlight} pointerEvents="none" />
+                <ScrollView
+                  ref={fracScrollRef}
+                  style={styles.drumScroll}
+                  showsVerticalScrollIndicator={false}
+                  snapToInterval={ITEM_HEIGHT}
+                  decelerationRate="fast"
+                  scrollEventThrottle={16}
+                  onMomentumScrollEnd={handleFracScroll}
+                  onScrollEndDrag={handleFracScroll}
+                  contentContainerStyle={{ paddingVertical: ITEM_HEIGHT * PAD_COUNT }}
+                >
+                  {FRACTION_LABELS.map((label, i) => (
+                    <View key={i} style={styles.drumItem}>
+                      <Text
+                        style={
+                          i === fractionIndex
+                            ? styles.drumItemTextSelected
+                            : styles.drumItemText
+                        }
+                      >
+                        {label}
+                      </Text>
+                    </View>
+                  ))}
+                </ScrollView>
+              </View>
             </View>
           </View>
 
           {/* Total display */}
-          <Text style={styles.totalText}>{totalDisplay} serving{currentTotal !== 1 ? 's' : ''}</Text>
+          <Text style={styles.totalText}>
+            {totalDisplay} serving{currentTotal !== 1 ? 's' : ''}
+          </Text>
         </>
       )}
 

--- a/components/settings/MacroSection.tsx
+++ b/components/settings/MacroSection.tsx
@@ -72,13 +72,6 @@ const makeStyles = (colors: typeof LightColors) =>
     presetTextActive: {
       color: colors.white,
     },
-    gramHint: {
-      ...Typography.small,
-      color: colors.textSecondary,
-      marginTop: 3,
-      textAlign: 'center',
-      fontSize: 11,
-    },
     customBtn: {
       backgroundColor: colors.background,
       borderRadius: Radius.sm,
@@ -103,15 +96,34 @@ const makeStyles = (colors: typeof LightColors) =>
       color: colors.textSecondary,
       marginBottom: Spacing.xs,
     },
-    customInput: {
+    stepperRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      width: '100%',
+      gap: 4,
+    },
+    stepperBtn: {
+      width: 32,
+      height: 36,
       backgroundColor: colors.background,
       borderRadius: Radius.sm,
-      paddingHorizontal: Spacing.sm,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    stepperBtnText: {
+      ...Typography.h3,
+      color: colors.primary,
+      lineHeight: 20,
+    },
+    stepperInput: {
+      flex: 1,
+      backgroundColor: colors.background,
+      borderRadius: Radius.sm,
+      paddingHorizontal: Spacing.xs,
       paddingVertical: Spacing.sm,
       ...Typography.body,
       color: colors.text,
       textAlign: 'center',
-      width: '100%',
     },
     validation: {
       ...Typography.small,
@@ -169,6 +181,23 @@ export default function MacroSection({ goalCalories }: Props) {
     }
   };
 
+  const clamp = (v: number) => Math.max(0, Math.min(100, v));
+
+  const stepProtein = (delta: number) => {
+    const newVal = clamp((parseInt(customProtein) || 0) + delta).toString();
+    handleCustomChange('protein', newVal, setCustomProtein);
+  };
+
+  const stepCarbs = (delta: number) => {
+    const newVal = clamp((parseInt(customCarbs) || 0) + delta).toString();
+    handleCustomChange('carbs', newVal, setCustomCarbs);
+  };
+
+  const stepFat = (delta: number) => {
+    const newVal = clamp((parseInt(customFat) || 0) + delta).toString();
+    handleCustomChange('fat', newVal, setCustomFat);
+  };
+
   const customSum = (parseInt(customProtein) || 0) + (parseInt(customCarbs) || 0) + (parseInt(customFat) || 0);
 
   return (
@@ -198,9 +227,6 @@ export default function MacroSection({ goalCalories }: Props) {
                 {preset.label}
               </Text>
             </TouchableOpacity>
-            <Text style={styles.gramHint}>
-              P {gramsFor(preset.split.protein, goalCalories, 4)} · C {gramsFor(preset.split.carbs, goalCalories, 4)} · F {gramsFor(preset.split.fat, goalCalories, 9)}
-            </Text>
           </View>
         ))}
       </View>
@@ -220,45 +246,84 @@ export default function MacroSection({ goalCalories }: Props) {
           <View style={styles.customRow}>
             <View style={styles.customGroup}>
               <Text style={styles.customLabel}>Protein %</Text>
-              <TextInput
-                style={styles.customInput}
-                value={customProtein}
-                onChangeText={(v) => handleCustomChange('protein', v, setCustomProtein)}
-                keyboardType="number-pad"
-                placeholder="30"
-                placeholderTextColor={colors.textSecondary}
-              />
-              <Text style={styles.gramHint}>
-                {gramsFor(parseInt(customProtein) || 0, goalCalories, 4)}
-              </Text>
+              <View style={styles.stepperRow}>
+                <TouchableOpacity
+                  style={styles.stepperBtn}
+                  onPress={() => stepProtein(-1)}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.stepperBtnText}>-</Text>
+                </TouchableOpacity>
+                <TextInput
+                  style={styles.stepperInput}
+                  value={customProtein}
+                  onChangeText={(v) => handleCustomChange('protein', v, setCustomProtein)}
+                  keyboardType="number-pad"
+                  placeholder="30"
+                  placeholderTextColor={colors.textSecondary}
+                />
+                <TouchableOpacity
+                  style={styles.stepperBtn}
+                  onPress={() => stepProtein(1)}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.stepperBtnText}>+</Text>
+                </TouchableOpacity>
+              </View>
             </View>
             <View style={styles.customGroup}>
               <Text style={styles.customLabel}>Carbs %</Text>
-              <TextInput
-                style={styles.customInput}
-                value={customCarbs}
-                onChangeText={(v) => handleCustomChange('carbs', v, setCustomCarbs)}
-                keyboardType="number-pad"
-                placeholder="40"
-                placeholderTextColor={colors.textSecondary}
-              />
-              <Text style={styles.gramHint}>
-                {gramsFor(parseInt(customCarbs) || 0, goalCalories, 4)}
-              </Text>
+              <View style={styles.stepperRow}>
+                <TouchableOpacity
+                  style={styles.stepperBtn}
+                  onPress={() => stepCarbs(-1)}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.stepperBtnText}>-</Text>
+                </TouchableOpacity>
+                <TextInput
+                  style={styles.stepperInput}
+                  value={customCarbs}
+                  onChangeText={(v) => handleCustomChange('carbs', v, setCustomCarbs)}
+                  keyboardType="number-pad"
+                  placeholder="40"
+                  placeholderTextColor={colors.textSecondary}
+                />
+                <TouchableOpacity
+                  style={styles.stepperBtn}
+                  onPress={() => stepCarbs(1)}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.stepperBtnText}>+</Text>
+                </TouchableOpacity>
+              </View>
             </View>
             <View style={styles.customGroup}>
               <Text style={styles.customLabel}>Fat %</Text>
-              <TextInput
-                style={styles.customInput}
-                value={customFat}
-                onChangeText={(v) => handleCustomChange('fat', v, setCustomFat)}
-                keyboardType="number-pad"
-                placeholder="30"
-                placeholderTextColor={colors.textSecondary}
-              />
-              <Text style={styles.gramHint}>
-                {gramsFor(parseInt(customFat) || 0, goalCalories, 9)}
-              </Text>
+              <View style={styles.stepperRow}>
+                <TouchableOpacity
+                  style={styles.stepperBtn}
+                  onPress={() => stepFat(-1)}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.stepperBtnText}>-</Text>
+                </TouchableOpacity>
+                <TextInput
+                  style={styles.stepperInput}
+                  value={customFat}
+                  onChangeText={(v) => handleCustomChange('fat', v, setCustomFat)}
+                  keyboardType="number-pad"
+                  placeholder="30"
+                  placeholderTextColor={colors.textSecondary}
+                />
+                <TouchableOpacity
+                  style={styles.stepperBtn}
+                  onPress={() => stepFat(1)}
+                  activeOpacity={0.7}
+                >
+                  <Text style={styles.stepperBtnText}>+</Text>
+                </TouchableOpacity>
+              </View>
             </View>
           </View>
           {customSum !== 100 && (

--- a/prd.md
+++ b/prd.md
@@ -46,3 +46,27 @@
 - Portion can be adjusted both before adding a food (inline in the food search flow) and after (tap an existing meal item to open a bottom-sheet editor with the same portion selector).
 
 **Implementation:** New `components/nutrition/PortionSelector.tsx` component with PanResponder-based whole slider, fraction chip row, keypad toggle, and live macro preview. `UPDATE_FOOD_IN_MEAL` action added to AppContext reducer. `CustomFoodForm.tsx` updated with quantity/unit picker and useEffect-driven calorie auto-compute. `AddFoodTab.tsx` replaces serving +/- buttons with PortionSelector. `FoodItem.tsx` adds a tap-to-edit bottom-sheet Modal using PortionSelector. `MealCategory.tsx` passes date/category props to FoodItem. `MacroSection.tsx` accepts a `goalCalories` prop and displays gram equivalents. `settings.tsx` gains collapsible card wrappers for Profile and Macros sections and computes `goalCalories` via `calculateDailyCalories()`.
+
+## Phase 6: Settings Polish, Drum Picker, and Custom Food Visibility [IN PROGRESS]
+
+### 6.1 — Remove gram hints from Macro Split section
+
+Remove the computed gram hint text displayed below each macro preset button (Balanced, High Protein, Keto) and below each custom percentage input (Protein %, Carbs %, Fat %) in the Settings > Macro Split section. The summary line at the bottom of the section (e.g., "P: 30% (150g) · C: 40% (200g) · F: 30% (75g)") remains.
+
+### 6.2 — Add +/- stepper buttons to custom macro inputs
+
+In the Settings > Macro Split > Custom section, add a minus (−) button to the left and a plus (+) button to the right of each percentage TextInput (Protein %, Carbs %, Fat %). Each press increments or decrements the value by 1%, clamped to [0, 100]. Dispatch to context only when the three values sum to 100% (existing validation behavior preserved).
+
+### 6.3 — Replace portion slider with iOS-style drum pickers
+
+Replace the PanResponder-based horizontal slider and fraction chip row in `PortionSelector` with two vertically scrollable drum pickers side by side:
+- Left drum: whole numbers 0–250
+- Right drum: fractions ⅛-increments (0, ⅛, ¼, ⅜, ½, ⅝, ¾, ⅞)
+
+Each drum uses a ScrollView with `snapToInterval` for snapping, `decelerationRate="fast"`, and an absolutely-positioned highlight bar over the center row. Initial scroll position is set from the `value` prop on mount. The keypad toggle mode is unchanged. The live macro preview row is unchanged.
+
+### 6.4 — Show custom foods when search query is empty
+
+In both `AddFoodTab` (food-to-meal flow) and `CreateMealFlow` (saved meal creation), display all custom foods in a "My Foods" section when the search query is empty (no characters typed). When the user types 1 or more characters, custom foods are filtered by name match. USDA API calls continue to require 2+ characters. This ensures custom foods are always accessible immediately without requiring a minimum search length.
+
+**Files changed:** `components/settings/MacroSection.tsx`, `components/nutrition/PortionSelector.tsx`, `components/nutrition/AddFoodTab.tsx`, `components/nutrition/CreateMealFlow.tsx`, `prd.md`


### PR DESCRIPTION
…visibility

- MacroSection: remove gram hint text below preset buttons and custom inputs; replace plain TextInputs with [−] input [+] stepper rows for Protein/Carbs/Fat
- PortionSelector: replace PanResponder slider + fraction chips with two side-by-side ScrollView drum pickers (whole 0–250 + fraction ⅛-increments), snapToInterval snapping, center-row highlight bar, and mount-time scroll init
- AddFoodTab: show all custom foods under a "My Foods" header when query is empty; filter at 1+ chars; "No results found" only after a USDA search
- CreateMealFlow: pre-populate search list with all custom foods on mount; handleSearch handles 0-char (all custom), 1-char (filtered custom), and 2+-char (custom + USDA) tiers; section label shows "My Foods" when empty
- prd.md: append Phase 6 requirements (6.1–6.4)

https://claude.ai/code/session_01EMFwi8GGmnMzaH6rrzjvBK