### PR TITLE
Add /interview and /push-changes custom skills

### DIFF
--- a/.claude/commands/interview.md
+++ b/.claude/commands/interview.md
@@ -1,0 +1,73 @@
+# Interview & Planning Skill
+
+You are helping the user plan updates to their HealthTracker app. Your job is to conduct a thorough interview, then replace `prd.md` entirely with a structured, implementation-ready plan.
+
+## When to invoke
+
+Invoke this skill automatically whenever the user mentions:
+- Planning new features or updates
+- Changes they want to make to the app
+- Ideas for improvements
+- "What should I work on next" style questions
+
+Also invoked explicitly via `/interview`.
+
+## Step 1 — Gather update ideas
+
+Use the `AskUserQuestion` tool to ask the user what updates they have in mind. Frame it broadly so they can list multiple ideas:
+
+> "What updates are you planning for the app? List as many ideas as you have — we'll flesh each one out."
+
+## Step 2 — Interview each idea
+
+For each idea the user provides, use `AskUserQuestion` to ask targeted follow-up questions until you have enough detail to write an unambiguous implementation spec. Ask about:
+
+- **UX behavior**: What exactly does the user see/tap/experience? What is the before and after?
+- **Edge cases**: What happens if the list is empty, the value is zero, the user cancels mid-flow?
+- **Affected components**: Which screens, tabs, or components are involved?
+- **Data / state changes**: Does this require new reducer actions, new state fields, or changes to AsyncStorage?
+- **Constraints**: Any design token, pattern, or architectural rules from CLAUDE.md that apply?
+
+Ask one `AskUserQuestion` call per ambiguous area. Keep drilling until you have no open questions.
+
+## Step 3 — Write the plan to prd.md
+
+Once all ideas are fully understood, **completely replace** `prd.md` with a fresh, well-structured plan.
+
+### prd.md format
+
+```
+# HealthTracker — Product Requirements
+
+## Phase N: [Theme of this batch of updates] [IN PROGRESS]
+
+### N.1 — [Update title]
+
+[2-4 sentence description of the problem or missing feature]
+
+**Changes:**
+- `ComponentName.tsx`: specific change
+- `OtherFile.tsx`: specific change
+
+### N.2 — [Update title]
+
+...
+
+---
+
+## Files Changed in Phase N
+
+- `path/to/file.tsx` — description of what changes
+- `path/to/other.tsx` — description of what changes
+```
+
+**Phase numbering:** Read the existing `prd.md` to find the highest phase number used, then increment by 1. If the file is empty or has no phases, start at Phase 1.
+
+**One sub-section per update idea.** Be specific — reference exact component names, prop names, state variable names, and action types from the codebase where known.
+
+## Step 4 — Confirm
+
+After writing the file, tell the user:
+- How many updates were captured
+- The phase number assigned
+- The file has been saved and is ready for implementation

--- a/.claude/commands/push-changes.md
+++ b/.claude/commands/push-changes.md
@@ -1,0 +1,88 @@
+# Push Changes Skill
+
+After completing any code change, this skill updates documentation, creates a new sub-branch off the current branch, commits all changes, and pushes to GitHub.
+
+## When to invoke
+
+Invoke this skill automatically after completing:
+- Any feature implementation
+- Any bug fix
+- Any refactor or code improvement
+
+Also invoked explicitly via `/push-changes`.
+
+## Step 1 — Update documentation
+
+Review what was changed and update docs as needed. Do **not** update files that were not affected.
+
+- **`CLAUDE.md`**: Add or update entries in Component Notes, Key Patterns, Architecture, or Runtime Requirements if:
+  - A new component was created
+  - A new pattern was introduced
+  - A new reducer action was added
+  - A new utility or helper was added
+  - An existing component's props, behavior, or usage changed significantly
+
+- **`.claude/commands/*.md`** (skill files): Update any skill whose instructions reference changed behavior (e.g., if dependency-check constraints changed).
+
+- **`README.md`**: Update only if it exists and public-facing behavior or setup instructions changed.
+
+## Step 2 — Determine current branch
+
+Run:
+```
+git branch --show-current
+```
+
+Note the result as `<source-branch>`.
+
+## Step 3 — Create a new sub-branch
+
+Generate a branch name using this format:
+```
+claude/<kebab-case-description>-<6-char-random-id>
+```
+
+Where:
+- `<kebab-case-description>` is a short (2-4 word) summary of what was implemented, e.g. `edit-meal-flow`, `keyboard-dismiss-fix`, `portion-selector-compact`
+- `<6-char-random-id>` is a random alphanumeric string to avoid collisions
+
+Create and switch to the branch:
+```
+git checkout -b claude/<description>-<id>
+```
+
+## Step 4 — Stage and commit
+
+Stage all changes:
+```
+git add -A
+```
+
+Commit with a descriptive message that summarizes what was implemented:
+```
+git commit -m "<summary of changes>"
+```
+
+The commit message should be one clear sentence describing the change (e.g. "Add EditMealFlow component with portion editing and UPDATE_SAVED_MEAL dispatch").
+
+## Step 5 — Push to GitHub
+
+Push the new branch:
+```
+git push -u origin claude/<description>-<id>
+```
+
+**Retry policy:** If the push fails due to a network error, retry up to 4 times with exponential backoff:
+- Wait 2s, retry
+- Wait 4s, retry
+- Wait 8s, retry
+- Wait 16s, retry
+
+Do **not** retry if the failure is a 403 (permission error) or branch naming issue — report the error to the user instead.
+
+## Step 6 — Report to user
+
+After a successful push, tell the user:
+- The branch name that was created and pushed
+- A summary of which documentation files were updated (if any)
+- The commit message used

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,12 @@ No test runner or lint script exists in package.json.
 
 - **`GestureHandlerRootView`** wraps the entire app in `app/_layout.tsx` — required by `react-native-gesture-handler` and any library that depends on it (e.g., `react-native-draggable-flatlist`). Must be the outermost wrapper.
 
+## Skills
+
+- **`/interview`** — Invoke automatically whenever the user mentions planning, update ideas, new features, or improvements to the app. Conducts a structured interview using `AskUserQuestion` and rewrites `prd.md` with a complete, phased implementation plan.
+- **`/push-changes`** — Invoke automatically after completing any code change (feature, fix, or refactor). Updates affected documentation, creates a new `claude/<description>-<id>` sub-branch off the current branch, commits all changes, and pushes to GitHub.
+- **`/dependency-check`** — For all version constraints, compatibility rules, and install commands.
+
 ## Dependency Management
 
 For all version constraints, compatibility rules, and install commands, use the `/dependency-check` skill.


### PR DESCRIPTION
- .claude/commands/interview.md: structured interview skill that uses AskUserQuestion to gather update ideas and rewrites prd.md with a phased implementation plan
- .claude/commands/push-changes.md: post-code-change skill that updates docs, creates a claude/<desc>-<id> sub-branch, commits, and pushes to GitHub
- CLAUDE.md: add Skills section with auto-invocation rules for both new skills and /dependency-check

https://claude.ai/code/session_018ooRYBPcQTEhBHANhwA2QM