### PR TITLE
Add automated Android APK GitHub Release pipeline (Phase 16)

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -1,0 +1,56 @@
+name: Android APK Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write  # required to create GitHub Releases
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup Expo and EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build Android APK via EAS
+        id: build
+        run: |
+          BUILD_JSON=$(eas build \
+            --platform android \
+            --profile preview \
+            --non-interactive \
+            --wait \
+            --json \
+            2>/dev/null)
+          BUILD_URL=$(echo "$BUILD_JSON" | jq -r '.[0].artifacts.buildUrl')
+          echo "build_url=$BUILD_URL" >> $GITHUB_OUTPUT
+
+      - name: Download APK
+        run: |
+          curl -L "${{ steps.build.outputs.build_url }}" \
+            -o "health-tracker-${{ github.ref_name }}.apk"
+
+      - name: Create GitHub Release with APK
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "HealthTracker ${{ github.ref_name }}"
+          generate_release_notes: true
+          files: "health-tracker-${{ github.ref_name }}.apk"

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,13 @@
+{
+  "cli": {
+    "version": ">= 7.0.0"
+  },
+  "build": {
+    "preview": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    }
+  }
+}

--- a/prd.md
+++ b/prd.md
@@ -523,3 +523,40 @@ After saving a weight entry the app showed `Alert.alert('Saved', ...)`. Replaced
 - `components/nutrition/AddMealTab.tsx` — add edit button, wire up EditMealFlow
 - `app/(tabs)/index.tsx` — call `Keyboard.dismiss()` in `handleSave()`
 - `prd.md` — this file
+
+
+---
+
+## Phase 16: Android APK Release Automation [IN PROGRESS]
+
+### 16.1 — GitHub Actions CI/CD: Automated Android APK Build & Release
+
+The app had no way to distribute builds to testers. Added a fully automated pipeline: pushing a git tag triggers an EAS cloud build, produces a downloadable debug APK, and attaches it to a GitHub Release — all without committing any binary to the repository.
+
+**Changes:**
+- `eas.json` *(new)*: EAS build configuration. Defines a `preview` profile with `distribution: "internal"` and `buildType: "apk"`. EAS auto-manages debug signing credentials — no keystore required.
+- `.github/workflows/release-android.yml` *(new)*: GitHub Actions workflow triggered on tags matching `v*.*.*`. Steps: checkout → Node 20 setup → `npm ci` → setup EAS CLI via `expo/expo-github-action@v8` (authenticated with `EXPO_TOKEN` secret) → `eas build --platform android --profile preview --wait --json` → parse artifact URL with `jq` → `curl` download → create GitHub Release with APK attached via `softprops/action-gh-release@v2`.
+
+**One-time manual prerequisites (run locally once before first tag):**
+1. `npm install -g eas-cli`
+2. `eas login` (Expo account required — free at expo.dev)
+3. `eas init` → adds `extra.eas.projectId` to `app.json`; commit this change
+4. Generate token at expo.dev → Account Settings → Access Tokens
+5. Add `EXPO_TOKEN` secret: GitHub repo → Settings → Secrets and variables → Actions
+
+**Releasing a new version:**
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+GitHub Actions builds (~10–20 min) and publishes the Release automatically.
+
+**Friend installs via:**
+GitHub repo → Releases → download `.apk` → Android Settings → enable "Install unknown apps" → tap APK to install.
+
+---
+
+## Files Changed in Phase 16
+
+- `eas.json` *(new)* — EAS build profile: internal APK distribution, debug signing
+- `.github/workflows/release-android.yml` *(new)* — tag-triggered GitHub Actions workflow: EAS build → download APK → create GitHub Release


### PR DESCRIPTION
- eas.json: EAS preview profile — internal APK distribution, debug signing
- .github/workflows/release-android.yml: tag-triggered workflow (v*.*.*) that runs EAS cloud build, downloads the APK artifact, and creates a GitHub Release with the APK attached via softprops/action-gh-release
- prd.md: Phase 16 documentation

One-time local prerequisite: eas login + eas init to link project to Expo cloud.
Releasing is then: git tag v1.0.0 && git push origin v1.0.0

https://claude.ai/code/session_016b3xXHfSxfELnhYTtrWgcK