### PR TITLE
Convert .claude/commands to .claude/skills with YAML frontmatter

### DIFF
--- a/.claude/skills/ci/SKILL.md
+++ b/.claude/skills/ci/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: ci
+description: Create Issues Skill. Invoke automatically when the user says "brainstorm", "idea dump", "create github issues", "sync issues", "push to board", or wants to explore ideas and track them on the GitHub project board.
+---
+
 # Create Issues Skill
 
 Brainstorm new ideas with the user, then push them directly to GitHub as labelled issues in the Backlog column of the HealthTracker Project board. No intermediate file — ideas go straight from conversation to GitHub.

--- a/.claude/skills/cp/SKILL.md
+++ b/.claude/skills/cp/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: cp
+description: Complete Prioritized Tickets Skill. Invoke automatically when the user says "work on prioritized", "complete the board", "do the prioritized tickets", "ship the prioritized items", or asks to work through the backlog.
+---
+
 # Complete Prioritized Tickets Skill
 
 Reads all open issues in the "Prioritized" column of the HealthTracker Project board, implements each one, then calls `/push-changes` to commit and push all changes on a new branch.

--- a/.claude/skills/cr/SKILL.md
+++ b/.claude/skills/cr/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: cr
+description: Create Release Skill. Creates a versioned Git tag, triggers the APK build pipeline, creates a GitHub Release, and archives Done items. Only invoked explicitly — never invoke automatically.
+disable-model-invocation: true
+---
+
 # Create Release Skill
 
 Creates a versioned Git tag on `main`, pushes it to GitHub (triggers the `release-android.yml` APK build pipeline), creates a GitHub Release with compiled release notes, and archives all Done items on the project board.

--- a/.claude/skills/dependency-check/SKILL.md
+++ b/.claude/skills/dependency-check/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: dependency-check
+description: Dependency Check for HealthTracker. Reference before installing any package, modifying package.json, or troubleshooting Metro/npm errors. Contains all version constraints and correct install commands.
+---
+
 # Dependency Check — HealthTracker
 
 Reference this skill before installing any package, modifying `package.json`, or

--- a/.claude/skills/interview/SKILL.md
+++ b/.claude/skills/interview/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: interview
+description: Interview & Planning Skill. Invoke automatically when the user mentions planning new features, updates, or improvements to the app, or asks "what should I work on next".
+---
+
 # Interview & Planning Skill
 
 You are helping the user plan updates to their HealthTracker app. Your job is to conduct a thorough interview, then write an implementation-ready plan to `prd.md`.

--- a/.claude/skills/push-changes/SKILL.md
+++ b/.claude/skills/push-changes/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: push-changes
+description: Push Changes Skill. Invoke automatically after completing any feature implementation, bug fix, refactor, or code improvement — updates docs, creates a sub-branch, commits, and pushes to GitHub.
+---
+
 # Push Changes Skill
 
 After completing any code change, this skill updates documentation, creates a new sub-branch off the current branch, commits all changes, and pushes to GitHub.
@@ -22,7 +27,7 @@ Review what was changed and update docs as needed. Do **not** update files that 
   - A new utility or helper was added
   - An existing component's props, behavior, or usage changed significantly
 
-- **`.claude/commands/*.md`** (skill files): Update any skill whose instructions reference changed behavior (e.g., if dependency-check constraints changed).
+- **`.claude/skills/*/SKILL.md`** (skill files): Update any skill whose instructions reference changed behavior (e.g., if dependency-check constraints changed).
 
 - **`README.md`**: Update only if it exists and public-facing behavior or setup instructions changed.
 

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,10 +1,15 @@
+---
+name: release-notes
+description: Release Notes Skill. Invoked automatically by /cr to compile release notes from Done items on the project board. Also usable standalone via /release-notes to preview upcoming release notes.
+---
+
 # Release Notes Skill
 
 Fetches all issues in the "Done" column of the HealthTracker Project board, deduplicates conflicting changes, and compiles formatted markdown release notes.
 
 ## When to invoke
 
-- Invoked automatically by `/create-release` (Step 4) to generate release body text.
+- Invoked automatically by `/cr` (Step 5) to generate release body text.
 - Can also be invoked explicitly via `/release-notes` to preview what the next release notes would look like.
 
 ## Step 1 — Fetch Done items from project board
@@ -101,6 +106,6 @@ Guidelines for each bullet:
 
 ## Step 6 — Output
 
-When invoked standalone (not from `/create-release`), display the compiled notes to the user as a formatted preview and stop.
+When invoked standalone (not from `/cr`), display the compiled notes to the user as a formatted preview and stop.
 
-When invoked from `/create-release`, return the compiled notes string for use in the next steps of that skill.
+When invoked from `/cr`, return the compiled notes string for use in the next steps of that skill.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,13 +75,15 @@ No test runner or lint script exists in package.json.
 
 ## Skills
 
+Skills are defined in `.claude/skills/*/SKILL.md` (modern format with YAML frontmatter).
+
 - **`/interview`** — Invoke automatically whenever the user mentions planning, update ideas, new features, or improvements to the app. Conducts a structured interview using `AskUserQuestion` and rewrites `prd.md` with a complete, phased implementation plan.
 - **`/push-changes`** — Invoke automatically after completing any code change (feature, fix, or refactor). Updates affected documentation, creates a new `claude/<description>-<id>` sub-branch off the current branch, commits all changes, and pushes to GitHub.
 - **`/dependency-check`** — For all version constraints, compatibility rules, and install commands.
 - **`/ci`** — Invoke automatically when user says "brainstorm", "idea dump", "create github issues", "sync issues", "push to board", or similar. Conducts a brainstorming interview, then creates labelled GitHub issues directly and adds them to the HealthTracker Project board in the Backlog column. No intermediate file — ideas go straight from conversation to GitHub.
 - **`/cp`** — Invoke automatically when user says "work on prioritized", "complete the board", "do the prioritized tickets", or similar. Reads all issues in the "Prioritized" column of the project board, implements each one, then calls `/push-changes` to commit and push on a new branch.
 - **`/cr`** — Only invoked explicitly. Asks major/minor bump type, auto-computes new version from `app.json` (`expo.version`), updates and commits `app.json`, compiles release notes via `/release-notes`, creates an annotated tag, pushes to GitHub (triggers the `release-android.yml` APK build pipeline), creates a GitHub Release with the compiled notes, then archives all Done items from the project board.
-- **`/release-notes`** — Invoked automatically by `/cr` (Step 4); also usable standalone. Fetches all issues in the "Done" column of the project board via GitHub GraphQL, sorts by `closedAt` descending, deduplicates conflicting items (keeps newest per feature area), categorises into ✨ New Features / 🐛 Bug Fixes / 🔧 Improvements, and returns formatted markdown release notes. Project board ID: `PVT_kwHODcEpUs4BRrsp`.
+- **`/release-notes`** — Invoked automatically by `/cr` (Step 5); also usable standalone. Fetches all issues in the "Done" column of the project board via GitHub GraphQL, sorts by `closedAt` descending, deduplicates conflicting items (keeps newest per feature area), categorises into ✨ New Features / 🐛 Bug Fixes / 🔧 Improvements, and returns formatted markdown release notes. Project board ID: `PVT_kwHODcEpUs4BRrsp`.
 
 ## Dependency Management
 


### PR DESCRIPTION
Migrates all 7 project skills from the legacy .claude/commands/*.md format to the modern .claude/skills/*/SKILL.md format with YAML frontmatter. Each skill now includes name and description fields; /cr uses disable-model-invocation: true to prevent auto-triggering.

https://claude.ai/code/session_01Y9Jmh65GFtq9yYYrru9sxy